### PR TITLE
FIX - revert command to check if partition exists

### DIFF
--- a/alien-extended-storage-types/alien-extended-storage-types.yml
+++ b/alien-extended-storage-types/alien-extended-storage-types.yml
@@ -2,7 +2,7 @@ tosca_definitions_version: alien_dsl_1_4_0
 
 metadata:
   template_name: alien-extended-storage-types
-  template_version: 1.4.1-SNAPSHOT
+  template_version: 1.4.2-SNAPSHOT
   template_author: alien4cloud
 
 imports:

--- a/alien-extended-storage-types/scripts/parted.sh
+++ b/alien-extended-storage-types/scripts/parted.sh
@@ -4,9 +4,9 @@ partition_number=1
 device_name=${DEVICE}
 
 echo "Checking existing partition for $device_name"
-sudo parted --script $device_name print 2>/dev/null | grep "Partition Table: unknown"
-PARTITION_UNKNOWN=$(echo $?)
-if [ $PARTITION_UNKNOWN -eq 0 ] ; then
+sudo fdisk -l $device_name 2>/dev/null | grep -E "$device_name[0-9]"
+PARTITION_EXISTENCE=$(echo $?)
+if [ $PARTITION_EXISTENCE -ne 0 ] ; then
     echo "Creating disk partition gpt on device ${device_name}"
     sudo parted --script $device_name \
         mklabel gpt \


### PR DESCRIPTION
By using the component on OpenStack, I encountered some weird case where parted was not consistant with the existence of a partition on the device.
As a consequence, I propose to revert the way a partition exists on the given device: fdisk seems to be more consistent and is able to read partitions.