### PR TITLE
add artifact puppet 

### DIFF
--- a/alien-base-types/alien-base-types.yml
+++ b/alien-base-types/alien-base-types.yml
@@ -24,3 +24,7 @@ artifact_types:
     derived_from: tosca.artifacts.Root
     mime_type: application/zip
     file_ext: [ ansible ]
+  org.alien4cloud.artifacts.PuppetRecipe:
+    derived_from: tosca.artifacts.Root
+    mime_type: application/zip
+    file_ext: [ puppet ]


### PR DESCRIPTION
To use Alien4Cloud with the puppet components, we need to add the artifact "PuppetRecipe" 