### PR TITLE
This script wont work for non English locales

### DIFF
--- a/alien-extended-storage-types/scripts/parted.sh
+++ b/alien-extended-storage-types/scripts/parted.sh
@@ -4,6 +4,7 @@ partition_number=1
 device_name=${DEVICE}
 
 echo "Checking existing partition for $device_name"
+export LC_ALL=C
 sudo parted --script $device_name print 2>/dev/null | grep "Partition Table: unknown"
 PARTITION_UNKNOWN=$(echo $?)
 if [ $PARTITION_UNKNOWN -eq 0 ] ; then


### PR DESCRIPTION
If the locale is set to another language than English (say French for instance :) ) it will not recognize the "Partition Table: unknown" pattern as parted will output something like that:
```
$ sudo parted --script /dev/vdb print
Erreur: Impossible d'ouvrir /dev/vdb - étiquette de disque non reconnue.
Modèle: Périphérique par blocs Virtio (virtblk)
Disque /dev/vdb : 2147MB
Taille des secteurs (logiques/physiques): 512B/512B
Table de partitions : unknown
Disk Flags: 
```

Setting LC_ALL ensure that we will get the expected output.