### PR TITLE
Update implementation artifacts

### DIFF
--- a/alien-base-types/alien-base-types.yml
+++ b/alien-base-types/alien-base-types.yml
@@ -12,11 +12,11 @@ description: Types supported by alien 4 cloud that extends the TOSCA specificati
 
 artifact_types:
   org.alien4cloud.artifacts.BatchScript:
-    derived_from: tosca.artifacts.Root
+    derived_from: tosca.artifacts.Implementation
     description: A Windows batch script (.bat or .cmd)
     file_ext: [ bat, cmd]
   org.alien4cloud.artifacts.AnsiblePlaybook:
-    derived_from: tosca.artifacts.Root
+    derived_from: tosca.artifacts.Implementation
     mime_type: application/zip
     file_ext: [ ansible ]
 


### PR DESCRIPTION
Just like `tosca.artifacts.Implementation.Bash` and `tosca.artifacts.Implementation.Python` it makes sens to make `org.alien4cloud.artifacts.BatchScript` and `org.alien4cloud.artifacts.AnsiblePlaybook` derive from `tosca.artifacts.Implementation`

This allows to detect them as implementation artifacts.